### PR TITLE
Integrates SDL3 and updates build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# CMakeLists.txt (Main)
 cmake_minimum_required(VERSION 3.16)
 project(GenesisEngine VERSION 0.1 LANGUAGES C CXX)
 
@@ -8,6 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-# Engine and Game subprojects
+# Add external dependencies and subprojects
+add_subdirectory(External/SDL)
 add_subdirectory(Engine)
 add_subdirectory(Game)

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -1,5 +1,16 @@
-file(GLOB_RECURSE ENGINE_HEADERS CONFIGURE_DEPENDS include/*.h)
-file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS src/*.cpp)
+# Engine/CMakeLists.txt
+file(GLOB_RECURSE ENGINE_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
+)
+file(GLOB_RECURSE ENGINE_HEADERS CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
+)
 
-add_library(GenesisEngine STATIC ${ENGINE_HEADERS} ${ENGINE_SOURCES})
-target_include_directories(GenesisEngine PUBLIC include)
+add_library(GenesisEngine STATIC ${ENGINE_SOURCES} ${ENGINE_HEADERS})
+
+target_include_directories(GenesisEngine PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/External/SDL/include
+)
+
+target_link_libraries(GenesisEngine PRIVATE SDL3::SDL3)

--- a/Engine/include/Platform/SDLWindow.h
+++ b/Engine/include/Platform/SDLWindow.h
@@ -1,0 +1,19 @@
+// Engine/include/Platform/SDLWindow.h
+#pragma once
+#include <SDL3/SDL.h>
+#include <string>
+
+namespace Engine {
+    class SDLWindow {
+    public:
+        SDLWindow(const std::string& title, int width, int height);
+        ~SDLWindow();
+        bool ShouldClose() const;
+        void PollEvents();
+        SDL_Window* GetSDLWindow() const;
+
+    private:
+        SDL_Window* m_Window;
+        bool m_ShouldClose;
+    };
+}

--- a/Engine/src/Platform/SDLWindow.cpp
+++ b/Engine/src/Platform/SDLWindow.cpp
@@ -1,0 +1,45 @@
+// Engine/src/Platform/SDLWindow.cpp
+#include "Platform/SDLWindow.h"
+#include <SDL3/SDL.h>
+
+namespace Engine {
+    SDLWindow::SDLWindow(const std::string& title, int width, int height) : m_ShouldClose(false) {
+        // Initialize SDL with video subsystem
+        if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+            SDL_Log("Failed to initialize SDL: %s", SDL_GetError());
+            m_ShouldClose = true;
+            return;
+        }
+
+        // Create window with basic flags (resizable for flexibility)
+        m_Window = SDL_CreateWindow(title.c_str(), width, height, SDL_WINDOW_RESIZABLE);
+        if (!m_Window) {
+            SDL_Log("Failed to create window: %s", SDL_GetError());
+            m_ShouldClose = true;
+        }
+    }
+
+    SDLWindow::~SDLWindow() {
+        if (m_Window) {
+            SDL_DestroyWindow(m_Window);
+        }
+        SDL_Quit();
+    }
+
+    bool SDLWindow::ShouldClose() const {
+        return m_ShouldClose;
+    }
+
+    void SDLWindow::PollEvents() {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_EVENT_QUIT) {
+                m_ShouldClose = true;
+            }
+        }
+    }
+
+    SDL_Window* SDLWindow::GetSDLWindow() const {
+        return m_Window;
+    }
+}

--- a/Game/CMakeLists.txt
+++ b/Game/CMakeLists.txt
@@ -1,7 +1,17 @@
-file(GLOB_RECURSE GAME_HEADERS CONFIGURE_DEPENDS include/*.h)
-file(GLOB_RECURSE GAME_SOURCES CONFIGURE_DEPENDS src/*.cpp)
+# Game/CMakeLists.txt
+file(GLOB_RECURSE GAME_HEADERS CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/*.h
+)
+file(GLOB_RECURSE GAME_SOURCES CONFIGURE_DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp
+)
 
 add_executable(GenesisGame ${GAME_HEADERS} ${GAME_SOURCES})
-target_include_directories(GenesisGame PRIVATE include)
 
-target_link_libraries(GenesisGame PRIVATE GenesisEngine)
+target_include_directories(GenesisGame PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/Engine/include
+    ${CMAKE_SOURCE_DIR}/External/SDL/include
+)
+
+target_link_libraries(GenesisGame PRIVATE GenesisEngine SDL3::SDL3)

--- a/Game/src/main.cpp
+++ b/Game/src/main.cpp
@@ -1,15 +1,16 @@
 #include "Engine/Engine.h"
 #include "Engine/Log.h"
+#include "Platform/SDLWindow.h"
 
 int main() {
     Engine::LogInit();
+    LOG_INFO("Genesis Game Starting...");
 
-    LOG_INFO("Engine starting up...");
-    LOG_DEBUG("This is a debug message.");
-    LOG_WARN("This is a warning.");
-    LOG_ERROR("This is an error!");
+    Engine::SDLWindow window("Genesis Engine", 1280, 720);
 
-    Engine::Initialize();
-    Engine::Shutdown();
+    while (!window.ShouldClose()) {
+        window.PollEvents();
+    }
+
     return 0;
 }


### PR DESCRIPTION
Adds SDL3 as a submodule and integrates it into the build process. Enhances the `Build.bat` script to clone, build, and link SDL3 statically. Updates CMake configurations to include SDL3 in the engine and game dependencies. Introduces an SDL-based window system to the game entry point.